### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: cpp
 
-sudo: false
 cache: ccache
 
-notifications:
-  irc: "chat.freenode.net##crow"
+dist: focal
+
 
 compiler:
   - gcc
@@ -28,7 +27,7 @@ addons:
       - g++-4.9
       - g++-5
       - clang-3.6
-      - libboost1.55-all-dev
+      - libboost-all-dev
       - python-pip
 
 install:
@@ -41,7 +40,7 @@ before_script:
   - cmake --version
   - cmake ..
 
-script: make -j2 && ctest -j2
+script: make -j2 && ctest -V -j2
 
 after_success:
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
       - g++-10
       - clang
       - libboost-all-dev
-      - python-pip
 
 install:
   - if [ "$PUSH_COVERAGE" == "ON" ]; then pip install --user cpp-coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
       - libboost-all-dev
 
 install:
-  - if [ "$PUSH_COVERAGE" == "ON" ]; then pip install --user cpp-coverage; fi
+  - if [ "$PUSH_COVERAGE" == "ON" ]; then pip install --user cpp-coveralls; fi
 
 before_script:
   - export CXX=$COMPILER CC=$CCOMPILER

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ compiler:
 
 env:
   matrix:
-    - COMPILER=g++-4.8 CCOMPILER=gcc-4.8 PUSH_COVERAGE=ON
-    - COMPILER=g++-4.9 CCOMPILER=gcc-4.9
-    - COMPILER=g++-5 CCOMPILER=gcc-5
-    - COMPILER=clang++-3.6 CCOMPILER=clang-3.6
+    - COMPILER=g++ CCOMPILER=gcc PUSH_COVERAGE=ON
+    - COMPILER=g++-8 CCOMPILER=gcc-8
+    - COMPILER=g++-10 CCOMPILER=gcc-10
+    - COMPILER=clang++ CCOMPILER=clang
 
 addons:
   apt:
@@ -21,17 +21,16 @@ addons:
       - ubuntu-toolchain-r-test
       - boost-latest
       - llvm-toolchain-precise
-      - llvm-toolchain-precise-3.6
     packages:
-      - g++-4.8
-      - g++-4.9
-      - g++-5
-      - clang-3.6
+      - g++
+      - g++-8
+      - g++-10
+      - clang
       - libboost-all-dev
       - python-pip
 
 install:
-  - if [ "$PUSH_COVERAGE" == "ON" ]; then pip install --user git+git://github.com/eddyxu/cpp-coveralls.git; fi
+  - if [ "$PUSH_COVERAGE" == "ON" ]; then pip install --user cpp-coverage; fi
 
 before_script:
   - export CXX=$COMPILER CC=$CCOMPILER
@@ -44,4 +43,4 @@ script: make -j2 && ctest -V -j2
 
 after_success:
   - cd ..
-  - if [ "$PUSH_COVERAGE" == "ON" ]; then coveralls --gcov gcov-4.8 -i include --gcov-options '\-lp'; fi
+  - if [ "$PUSH_COVERAGE" == "ON" ]; then coveralls -i include --gcov-options '\-lp'; fi

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Crow is C++ microframework for web. (inspired by Python Flask)
 
-[![Travis Build](https://travis-ci.org/ipkn/crow.svg?branch=master)](https://travis-ci.org/ipkn/crow)
-[![Coverage Status](https://coveralls.io/repos/ipkn/crow/badge.svg?branch=master)](https://coveralls.io/r/ipkn/crow?branch=master)
+[![Travis Build](https://travis-ci.org/mrozigor/crow.svg?branch=master)](https://travis-ci.org/mrozigor/crow)
+[![Coverage Status](https://coveralls.io/repos/github/mrozigor/crow/badge.svg?branch=master)](https://coveralls.io/github/mrozigor/crow?branch=master)
 
 ```c++
 #include "crow.h"

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ If you just want to use crow, copy amalgamate/crow_all.h and include it.
 
 ### Requirements
 
- - C++ compiler with good C++11 support (tested with g++>=4.8)
- - boost library
- - CMake for build examples
- - Linking with tcmalloc/jemalloc is recommended for speed.
+ - C++ compiler with good C++11 support (tested with g++>=8).
+ - boost 1.7 library.
+ - (optional) CMake to build tests and/or examples.
+ - (optional) Linking with tcmalloc/jemalloc is recommended for speed.
 
  - Now supporting VS2013 with limited functionality (only run-time check for url is available.)
 


### PR DESCRIPTION
Crow originally used Ubuntu 16.04 LTS, which was fine in 2016, but is causing a few problems now.

This PR does the following:

- Updates the Travis OS to Ubuntu focal (**20.04.1 LTS**).
- Removes IRC notification on build.
- Updates GCC and G++ to versions **8**, **9** (default), and **10** (from **4.8**, **4.9**, and **5**). Also updates clang from **3.6** to **10.0**.
- Updates Boost version from **1.55** to **1.71**.
- Uses default pip link for coveralls.
- Uses verbose CTest (since all unit tests are considered 1 test).
- Uses links for `mrozigor/crow` instead of `ipkn/crow` in readme badges.
- Updates compiler and boost versions in `readme.md`

Closes #9

**Edit**: If this gets merged you'll need to enable the repo in travis and coveralls.