### PR TITLE
Streaming response bodies

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -487,7 +487,7 @@ namespace crow
 #endif
         void do_write_general()
         {
-            if (res.body.length() < megabyte)
+            if (res.body.length() < res_stream_threshold_)
             {
                 res_body_copy_.swap(res.body);
                 buffers_.emplace_back(res_body_copy_.data(), res_body_copy_.size());
@@ -624,7 +624,7 @@ namespace crow
 
         boost::array<char, 4096> buffer_;
 
-        const uint megabyte = 1048576;
+        const uint res_stream_threshold_ = 1048576;
 
         HTTPParser<Connection> parser_;
         request req_;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1245,3 +1245,39 @@ TEST_CASE("send_file")
     REQUIRE(404 == res.code);
   }
 }
+
+TEST_CASE("stream_response")
+{
+
+    SimpleApp app;
+
+    CROW_ROUTE(app, "/test")
+    ([](const crow::request&, crow::response& res)
+    {
+      std::string keyword_ = "hello";
+      std::string key_response;
+      for (unsigned int i = 0; i<1000000; i++)
+        key_response += keyword_;
+      res.body = key_response;
+      res.end();
+    });
+
+    app.validate();
+
+    {
+        std::string keyword_ = "hello";
+        std::string key_response;
+        for (unsigned int i = 0; i<1000000; i++)
+          key_response += keyword_;
+
+        request req;
+        response res;
+
+        req.url = "/test";
+
+        app.handle(req, res);
+
+        REQUIRE(key_response == res.body);
+    }
+
+}


### PR DESCRIPTION
Basically, if a response is larger than 1MB, it gets streamed the same way a static file does, this makes it so large responses don't get the 5 second timeout normal responses get

Note: this might be a problem when considering something like a DOS attack.

Closes #16 