### PR TITLE
Websocket updates

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,13 +38,13 @@ PROJECT_NAME           = Crow
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.1
+PROJECT_NUMBER         = 0.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "C++ microframework for the web"
+PROJECT_BRIEF          = "A C++ microframework for the web"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -121,12 +121,12 @@ namespace crow
         ///Set the server's log level
 
         ///
-        /// Possible values are:
-        /// crow::LogLevel::Debug       (0)
-        /// crow::LogLevel::Info        (1)
-        /// crow::LogLevel::Warning     (2)
-        /// crow::LogLevel::Error       (3)
-        /// crow::LogLevel::Critical    (4)
+        /// Possible values are:<br>
+        /// crow::LogLevel::Debug       (0)<br>
+        /// crow::LogLevel::Info        (1)<br>
+        /// crow::LogLevel::Warning     (2)<br>
+        /// crow::LogLevel::Error       (3)<br>
+        /// crow::LogLevel::Critical    (4)<br>
         self_t& loglevel(crow::LogLevel level)
         {
             crow::logger::setLogLevel(level);

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -108,11 +108,6 @@ namespace crow
 
         bool is_open()
         {
-            return raw_socket().is_open();
-        }
-
-        bool is_open()
-        {
             return ssl_socket_ ? raw_socket().is_open() : false;
         }
 

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -111,28 +111,45 @@ namespace crow
             return raw_socket().is_open();
         }
 
+        bool is_open()
+        {
+            return ssl_socket_ ? raw_socket().is_open() : false;
+        }
+
         void close()
         {
-            boost::system::error_code ec;
-            raw_socket().close(ec);
+            if (is_open())
+            {
+                boost::system::error_code ec;
+                raw_socket().close(ec);
+            }
         }
 
         void shutdown_readwrite()
         {
-            boost::system::error_code ec;
-            raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+            if (is_open())
+            {
+                boost::system::error_code ec;
+                raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+            }
         }
 
         void shutdown_write()
         {
-            boost::system::error_code ec;
-            raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_send, ec);
+            if (is_open())
+            {
+                boost::system::error_code ec;
+                raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_send, ec);
+            }
         }
 
         void shutdown_read()
         {
-            boost::system::error_code ec;
-            raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_receive, ec);
+            if (is_open())
+            {
+                boost::system::error_code ec;
+                raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_receive, ec);
+            }
         }
 
         boost::asio::io_service& get_io_service()

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -112,6 +112,21 @@ namespace crow
                     adaptor_.get_io_service().post(handler);
                 }
 
+                /// Send a "Ping" message.
+
+                ///
+                /// Usually invoked to check if the other point is still online.
+                void send_ping(const std::string& msg)
+                {
+                    dispatch([this, msg]{
+                        char buf[3] = "\x89\x00";
+                        buf[1] += msg.size();
+                        write_buffers_.emplace_back(buf, buf+2);
+                        write_buffers_.emplace_back(msg);
+                        do_write();
+                    });
+                }
+
                 /// Send a "Pong" message.
 
                 ///

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -54,7 +54,7 @@ namespace crow
         // |                     Payload Data continued ...                |
         // +---------------------------------------------------------------+
 
-        ///A websocket connection.
+        /// A websocket connection.
 		template <typename Adaptor>
         class Connection : public connection
         {
@@ -121,9 +121,8 @@ namespace crow
                 void send_ping(const std::string& msg) override
                 {
                     dispatch([this, msg]{
-                        char buf[3] = "\x89\x00";
-                        buf[1] += msg.size();
-                        write_buffers_.emplace_back(buf, buf+2);
+                        auto header = build_header(0x9, msg.size());
+                        write_buffers_.emplace_back(std::move(header));
                         write_buffers_.emplace_back(msg);
                         do_write();
                     });
@@ -136,9 +135,8 @@ namespace crow
                 void send_pong(const std::string& msg) override
                 {
                     dispatch([this, msg]{
-                        char buf[3] = "\x8A\x00";
-                        buf[1] += msg.size();
-                        write_buffers_.emplace_back(buf, buf+2);
+                        auto header = build_header(0xA, msg.size());
+                        write_buffers_.emplace_back(std::move(header));
                         write_buffers_.emplace_back(msg);
                         do_write();
                     });

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1371,3 +1371,137 @@ TEST_CASE("stream_response")
     });
     runTest.join();
 }
+
+TEST_CASE("websocket")
+{
+  static std::string http_message = "GET /ws HTTP/1.1\r\nConnection: keep-alive, Upgrade\r\nupgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+
+  static bool connected{false};
+
+  SimpleApp app;
+
+  CROW_ROUTE(app, "/ws").websocket()
+  .onopen([&](websocket::connection&){
+      connected = true;
+      CROW_LOG_INFO << "Connected websocket and value is " << connected;
+  })
+  .onmessage([&](websocket::connection& conn, const std::string& message, bool isbin){
+      CROW_LOG_INFO << "Message is \"" << message << '\"';
+      if (!isbin && message == "PINGME")
+          conn.send_ping("");
+      else if (!isbin && message == "Hello")
+          conn.send_text("Hello back");
+      else if (isbin && message == "Hello bin")
+          conn.send_binary("Hello back bin");
+  })
+  .onclose([&](websocket::connection&, const std::string&){
+      CROW_LOG_INFO << "Closing websocket";
+  });
+
+  app.validate();
+
+  auto _ = async(launch::async,
+                 [&] { app.bindaddr(LOCALHOST_ADDRESS).port(45451).run(); });
+  app.wait_for_server_start();
+  asio::io_service is;
+
+  asio::ip::tcp::socket c(is);
+  c.connect(asio::ip::tcp::endpoint(
+      asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+
+
+  char buf[2048];
+
+  //----------Handshake----------
+  {
+    std::fill_n (buf, 2048, 0);
+    c.send(asio::buffer(http_message));
+
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    CHECK(connected);
+  }
+  //----------Pong----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char ping_message[2]("\x89");
+
+    c.send(asio::buffer(ping_message, 2));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    CHECK((int)(unsigned char)buf[0] == 0x8A);
+  }
+  //----------Ping----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char not_ping_message[2+6+1]("\x81\x06"
+                                 "PINGME");
+
+    c.send(asio::buffer(not_ping_message, 8));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    CHECK((int)(unsigned char)buf[0] == 0x89);
+  }
+  //----------Text----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char text_message[2+5+1]("\x81\x05"
+                             "Hello");
+
+    c.send(asio::buffer(text_message, 7));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::string checkstring(std::string(buf).substr(0, 12));
+    CHECK(checkstring == "\x81\x0AHello back");
+  }
+  //----------Binary----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char bin_message[2+9+1]("\x82\x09"
+                            "Hello bin");
+
+    c.send(asio::buffer(bin_message, 11));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::string checkstring2(std::string(buf).substr(0, 16));
+    CHECK(checkstring2 == "\x82\x0EHello back bin");
+  }
+  //----------Masked Text----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char text_masked_message[2+4+5+1]("\x81\x85"
+                                      "\x67\xc6\x69\x73"
+                                      "\x2f\xa3\x05\x1f\x08");
+
+    c.send(asio::buffer(text_masked_message, 11));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::string checkstring3(std::string(buf).substr(0, 12));
+    CHECK(checkstring3 == "\x81\x0AHello back");
+  }
+  //----------Masked Binary----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char bin_masked_message[2+4+9+1]("\x82\x89"
+                                     "\x67\xc6\x69\x73"
+                                     "\x2f\xa3\x05\x1f\x08\xe6\x0b\x1a\x09");
+
+    c.send(asio::buffer(bin_masked_message, 15));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::string checkstring4(std::string(buf).substr(0, 16));
+    CHECK(checkstring4 == "\x82\x0EHello back bin");
+  }
+  //----------Close----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char close_message[10]("\x88"); //I do not know why, but the websocket code does not read this unless it's longer than 4 or so bytes
+
+    c.send(asio::buffer(close_message, 10));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    CHECK((int)(unsigned char)buf[0] == 0x88);
+  }
+
+  app.stop();
+}


### PR DESCRIPTION
This PR:
- Documents `websocket.h` and adds websocket message structure illustration.
- Cleans up a small problem with `app.h` documentation.
- Adds support for non masked client messages. (closes #43)
- Adds functionality to send a ping message from the server.
- Exposes methods to send Ping and Pong to the end-user.
- Resets the internal header variable before every read. (fixing potential issues where read is run and no actual data is taken from the socket)
- Adds a test for websockets. (#21)
- Implements ipkn#328 (fixing a potential crash when using SSL websockets).
- Allows for Ping and Pong payloads to be larger than 127 bytes.

I apologize ahead of time for any typos I missed.