### PR TITLE
Added default "static/<path>" route for any static files

### DIFF
--- a/examples/example_static_file.cpp
+++ b/examples/example_static_file.cpp
@@ -1,3 +1,5 @@
+//#define CROW_STATIC_DRIECTORY "alternative_directory/"
+//#define CROW_STATIC_ENDPOINT "/alternative_endpoint/<path>"
 #include "crow.h"
 
 int main()
@@ -20,3 +22,8 @@ CROW_ROUTE(app, "/")
 	
 	return 0;
 }
+
+/// You can also use the `/static` directory and endpoint (the directory needs to have the same path as your executable).
+/// Any file inside the static directory will have the same path it would in your filesystem.
+
+/// TO change the static directory or endpoint, use the macros above (replace `alternative_directory` and/or `alternative_endpoint` with your own)

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -165,7 +165,7 @@ namespace crow
             route<crow::black_magic::get_parameter_tag("/static/<path>")>("/static/<path>")
             ([](const crow::request&, crow::response& res, std::string file_path)
             {
-              res.set_static_file_info(file_path);
+              res.set_static_file_info("static/"+file_path);
               res.end();
             });
             validate();

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -161,7 +161,16 @@ namespace crow
         ///Run the server
         void run()
         {
+#ifndef CROW_DISABLE_STATIC_DIR
+            route<crow::black_magic::get_parameter_tag("/static/<path>")>("/static/<path>")
+            ([](const crow::request&, crow::response& res, std::string file_path)
+            {
+              res.set_static_file_info(file_path);
+              res.end();
+            });
             validate();
+#endif
+
 #ifdef CROW_ENABLE_SSL
             if (use_ssl_)
             {

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -162,10 +162,10 @@ namespace crow
         void run()
         {
 #ifndef CROW_DISABLE_STATIC_DIR
-            route<crow::black_magic::get_parameter_tag("/static/<path>")>("/static/<path>")
-            ([](const crow::request&, crow::response& res, std::string file_path)
+            route<crow::black_magic::get_parameter_tag(CROW_STATIC_ENDPOINT)>(CROW_STATIC_ENDPOINT)
+            ([](const crow::request&, crow::response& res, std::string file_path_partial)
             {
-              res.set_static_file_info("static/"+file_path);
+              res.set_static_file_info(CROW_STATIC_DIRECTORY + file_path_partial);
               res.end();
             });
             validate();

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -25,6 +25,13 @@
 #define CROW_LOG_LEVEL 1
 #endif
 
+#ifndef CROW_STATIC_DIRECTORY
+#define CROW_STATIC_DIRECTORY "static/"
+#endif
+#ifndef CROW_STATIC_ENDPOINT
+#define CROW_STATIC_ENDPOINT "/static/<path>"
+#endif
+
 
 // compiler flags
 #if __cplusplus >= 201402L


### PR DESCRIPTION
allows anyone to put whatever file in a `static` folder, the files there will be fully accessible.

can be disabled via `CROW_DISABLE_STATIC_DIR` def.

closes #41 