### PR TITLE
Activate static_file support on WIN32

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -465,7 +465,7 @@ namespace crow
             buffers_.emplace_back(crlf.data(), crlf.size());
             
         }
-#if !defined(_WIN32)
+
         void do_write_static()
         {
             is_writing = true;
@@ -476,15 +476,7 @@ namespace crow
             res.clear();
             buffers_.clear();
         }
-#else //TODO support windows
-        void do_write_static(){
-            CROW_LOG_INFO << "windows static file support is not ready";
-            res.code = 500;
-            res.end();
-            res.clear();
-            buffers_.clear();
-        }
-#endif
+
         void do_write_general()
         {
             if (res.body.length() < res_stream_threshold_)

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -134,7 +134,7 @@ namespace crow
   * middlware must call res.set_static_file_info(filename)
   * you must add route starting with /your/restricted/path/<string>
   */
-#if !defined(_WIN32)
+
         struct static_file_info{
             std::string path = "";
             struct stat statbuf;
@@ -187,7 +187,7 @@ namespace crow
                 write_streamed_string(body, adaptor);
             }
         }
-#endif
+
 /* static file support end */
         private:
             bool completed_{};

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -12,9 +12,8 @@
 #include "crow/socket_adaptors.h"
 #include "crow/logging.h"
 #include "crow/mime_types.h"
-#if !defined(_WIN32)
 #include <sys/stat.h>
-#endif
+
 
 namespace crow
 {


### PR DESCRIPTION
static_file support seems to work, at least with
Microsoft Visual Studio 2017 and 2109 / C++17.
Without it the compilation fails, so activating it.