### PR TITLE
Fix #include for example_with_all.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(PROJECT_INCLUDE_DIR
 
 include_directories("${PROJECT_INCLUDE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")  # To include crow_all.h
 
 add_subdirectory(examples)
 

--- a/examples/example_with_all.cpp
+++ b/examples/example_with_all.cpp
@@ -1,4 +1,4 @@
-#include "../build/crow_all.h"
+#include "crow_all.h"
 
 #include <sstream>
 


### PR DESCRIPTION
 Using relative directories like "../build/crow_all.h" might not work in all settings.