### PR TITLE
Rename CMake target: example -> basic_example.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,12 +26,12 @@ add_custom_command(OUTPUT ws.html
 )
 add_custom_target(example_ws_copy ALL DEPENDS ws.html)
 
-add_executable(example example.cpp)
-target_link_libraries(example ${Boost_LIBRARIES})
-target_link_libraries(example ${CMAKE_THREAD_LIBS_INIT})
+add_executable(basic_example example.cpp)
+target_link_libraries(basic_example ${Boost_LIBRARIES})
+target_link_libraries(basic_example ${CMAKE_THREAD_LIBS_INIT})
 
 if (Tcmalloc_FOUND)
-  target_link_libraries(example ${Tcmalloc_LIBRARIES})
+  target_link_libraries(basic_example ${Tcmalloc_LIBRARIES})
 endif(Tcmalloc_FOUND)
 
 add_executable(example_with_all example_with_all.cpp)


### PR DESCRIPTION
Gist: Try to avoid super generic target names since CMake puts it all at a global namespace.

**Personal context**: I currently have a project that pulls in `grpc` dependecy (and transitively `zlib`) via git clone and add_subdirectory. Unforutunately, CMake puts all targets in the global namespace and requires them to be unique. This is an issue because both $THIS_REPO/examples/CMakeLists.txt and [$ZLIB/CMakeLists.txt](https://github.com/madler/zlib/blob/master/CMakeLists.txt#L233) define the same target named `example`. This causes CMake step to fail.
